### PR TITLE
Adding onBackPressed to collapse BottomSheet

### DIFF
--- a/app/src/main/java/com/lucasmontano/openweathermap/IOnBackPressed.kt
+++ b/app/src/main/java/com/lucasmontano/openweathermap/IOnBackPressed.kt
@@ -1,0 +1,5 @@
+package com.lucasmontano.openweathermap
+
+interface IOnBackPressed {
+    fun onBackPressed(): Boolean
+}

--- a/app/src/main/java/com/lucasmontano/openweathermap/MainActivity.kt
+++ b/app/src/main/java/com/lucasmontano/openweathermap/MainActivity.kt
@@ -2,11 +2,20 @@ package com.lucasmontano.openweathermap
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    override fun onBackPressed() {
+        val fragment =
+            this.supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as? NavHostFragment
+        val currentFragment = fragment?.childFragmentManager?.fragments?.get(0) as? IOnBackPressed
+
+        currentFragment?.onBackPressed()?.takeIf { !it }?.let { super.onBackPressed() }
     }
 }

--- a/app/src/main/java/com/lucasmontano/openweathermap/map/ui/MapsFragment.kt
+++ b/app/src/main/java/com/lucasmontano/openweathermap/map/ui/MapsFragment.kt
@@ -17,6 +17,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.card.MaterialCardView
+import com.lucasmontano.openweathermap.IOnBackPressed
 import com.lucasmontano.openweathermap.R
 import com.lucasmontano.openweathermap.map.viewmodel.MapViewModel
 import com.lucasmontano.openweathermap.model.domain.LocationWeatherModel
@@ -25,7 +26,7 @@ import kotlinx.android.synthetic.main.fragment_maps.*
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MapsFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCameraMoveListener,
-    GoogleMap.OnCameraIdleListener {
+    GoogleMap.OnCameraIdleListener, IOnBackPressed {
 
     private var isExploring: Boolean = true
     private lateinit var sheetBehavior: BottomSheetBehavior<MaterialCardView>
@@ -264,5 +265,14 @@ class MapsFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnCameraMoveListe
             mMap.cameraPosition.target.latitude,
             mMap.cameraPosition.target.longitude
         )
+    }
+
+    override fun onBackPressed(): Boolean {
+        return if (sheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+            sheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            true
+        } else {
+            false
+        }
     }
 }


### PR DESCRIPTION
By adding this when the user presses the back button instead of closing the app when there is a BottomSheet on screen, the BottonSheet will close.